### PR TITLE
Fix `test_mulled_build.py::test_mulled_build_files_cli` with `use_mamba=True`

### DIFF
--- a/lib/galaxy/tool_util/deps/mulled/invfile.lua
+++ b/lib/galaxy/tool_util/deps/mulled/invfile.lua
@@ -88,13 +88,14 @@ inv.task('build')
     .using(conda_image)
         .withHostConfig({binds = bind_args})
         .run('/bin/sh', '-c', preinstall
+            .. conda_bin .. ' create --quiet --yes -p /usr/local/env --copy  && '
             .. conda_bin .. ' install '
             .. channel_args .. ' '
             .. target_args
-            .. ' --strict-channel-priority -p /usr/local --copy --yes '
+            .. ' --strict-channel-priority -p /usr/local/env --copy --yes '
             .. verbose
             .. postinstall)
-    .wrap('build/dist')
+    .wrap('build/dist/env')
         .at('/usr/local')
         .inImage(destination_base_image)
         .as(repo)


### PR DESCRIPTION
Test `tests/tool_util/mulled/test_mulled_build.py::test_mulled_build_files_cli[True]`, where `[True]` refers to the parameter `use_mamba`, fails because `mamba install -p /usr/local` expects either `/usr/local` not to exist or to be an existing environment.

Create an environment in `/usr/local/env` instead, but still put it on the expected location `/usr/local` later.

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
